### PR TITLE
Replace serde_yaml with serde_norway due to maintenance concerns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
  "pest",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_norway",
  "toml_edit",
 ]
 
@@ -477,7 +477,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_bytes",
  "serde_json",
- "serde_yaml",
+ "serde_norway",
  "thiserror",
  "toml_edit",
  "wasm-bindgen",
@@ -899,25 +899,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1037,10 +1037,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "utf8parse"

--- a/corn-cli/Cargo.toml
+++ b/corn-cli/Cargo.toml
@@ -14,6 +14,6 @@ clap = { version = "4.5.31", features = ["derive"] }
 colored = "3.0.0"
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.140"
-serde_yaml = "0.9.34"
+serde_norway = "0.9.42"
 toml_edit = { version = "0.22.24", features = ["serde"] }
 pest = "2.7.15"

--- a/corn-cli/src/bin/corn.rs
+++ b/corn-cli/src/bin/corn.rs
@@ -83,7 +83,7 @@ fn get_output_type(arg: Option<OutputType>) -> OutputType {
 fn serialize(config: &Value, output_type: OutputType) -> Result<String, Error> {
     match output_type {
         OutputType::Json => serde_json::to_string_pretty(&config).map_err(Error::from),
-        OutputType::Yaml => serde_yaml::to_string(&config).map_err(Error::from),
+        OutputType::Yaml => serde_norway::to_string(&config).map_err(Error::from),
         OutputType::Toml => toml_edit::ser::to_string_pretty(&config).map_err(Error::from),
     }
 }

--- a/corn-cli/src/error.rs
+++ b/corn-cli/src/error.rs
@@ -55,8 +55,8 @@ impl From<serde_json::Error> for Error {
     }
 }
 
-impl From<serde_yaml::Error> for Error {
-    fn from(err: serde_yaml::Error) -> Self {
+impl From<serde_norway::Error> for Error {
+    fn from(err: serde_norway::Error) -> Self {
         Self::Serializing(err.to_string())
     }
 }

--- a/libcorn/Cargo.toml
+++ b/libcorn/Cargo.toml
@@ -52,7 +52,7 @@ paste = "1.0.15"
 wasm-bindgen-test = { version = "0.3.50" }
 # required for testing
 serde_json = "1.0.140"
-serde_yaml = "0.9.34"
+serde_norway = "0.9.42"
 serde_bytes = "0.11.16"
 toml_edit = { version = "0.22.24", features = ["serde"] }
 

--- a/libcorn/tests/parser_tests.rs
+++ b/libcorn/tests/parser_tests.rs
@@ -29,7 +29,7 @@ macro_rules! generate_eq_tests {
                     let valid = fs::read_to_string(format!("../assets/outputs/yaml/{}.yml", test_name)).unwrap().replace("\r", "");
 
                     let config = parse(input.as_str()).unwrap();
-                    let serialized = serde_yaml::to_string(&config).unwrap().replace("\r", "");
+                    let serialized = serde_norway::to_string(&config).unwrap().replace("\r", "");
 
                     assert_eq!(serialized.trim(), valid.trim());
                 }


### PR DESCRIPTION
serde_yaml has been deprecated and is no longer maintained. After evaluating alternatives, serde_norway appears to be the most actively maintained fork at present. While not perfect, it provides a more sustainable dependency than an unmaintained library.

The current YAML ecosystem in rust is rather bleak, with several alternatives having various drawbacks. For context on the situation:
- https://www.reddit.com/r/rust/comments/1ibdxf9/beware_of_this_guy_making_slop_crates_with_ai/
- https://nitter.poast.org/davidtolnay/status/1883906113428676938
- https://github.com/rustsec/advisory-db/issues/2132

In the longer term I am considering rolling my own lib, but this change should address the immediate concern.

Depends on #38